### PR TITLE
removed 2902 descriptor

### DIFF
--- a/BLE/cycling-power-measurement-characteristic.js
+++ b/BLE/cycling-power-measurement-characteristic.js
@@ -17,11 +17,6 @@ class CyclingPowerMeasurementCharacteristic extends  Bleno.Characteristic {
 		value: 'Cycling Power Measurement'
 	}),
 	new Bleno.Descriptor({
-		// Client Characteristic Configuration
-		uuid: '2902',
-		value: Buffer.alloc(2)
-	}),
-	new Bleno.Descriptor({
 		// Server Characteristic Configuration
 		uuid: '2903',
 		value: Buffer.alloc(2)


### PR DESCRIPTION
removed 2902 descriptor to see if helped with windows 10 compatibility.

Zwift and sufferfest now see cadence and power with correct readings under windows 10. - HR selectable but still no HR numbers (just 0) in w10

Zwift, rgt and peloton still work on iOS with this setting changed. power cadence and HR